### PR TITLE
Make shebang more robust

### DIFF
--- a/smtpsmug
+++ b/smtpsmug
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import argparse
 import base64


### PR DESCRIPTION
Not all distros ship a 'python' executable, so defining 'python3' explicitly is probably a better idea. And by using '/usr/bin/env' this also works on more setups (like my NixOS machine).

Best,
fleaz