### PR TITLE
Fix RFC reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To test the postfix mitigation, there is now a `pipelining` test. (May be unstab
 There are multiple behaviors of mail servers that enable the vulnerability:
 
 * Mail servers accept malformed endings. This is in all cases a bug and a violation of
-  [RFC 5321, section 4.4.1](https://www.rfc-editor.org/rfc/rfc5321#section-4.1.4).
+  [RFC 5321, section 4.1.1.4](https://www.rfc-editor.org/rfc/rfc5321#section-4.1.1.4).
 
 * Mail servers accept malformed endings within mails and forward them to other mail
   servers. To test this, you need to monitor the receiving side. (The


### PR DESCRIPTION
It's section 4.1.1.4 that says:

```
   The custom of accepting lines ending only in <LF>, as a concession to
   non-conforming behavior on the part of some UNIX systems, has proven
   to cause more interoperability problems than it solves, and SMTP
   server systems MUST NOT do this, even in the name of improved
   robustness.  In particular, the sequence "<LF>.<LF>" (bare line
   feeds, without carriage returns) MUST NOT be treated as equivalent to
   <CRLF>.<CRLF> as the end of mail data indication.
```