### PR TITLE
test case fixed with copy past mistake

### DIFF
--- a/smtpsmug
+++ b/smtpsmug
@@ -138,7 +138,7 @@ tests = {
     "crcrlf": "\r.\r\n",
     "crlfcr": "\r\n.\r",
     "nullbefore": "\r\n\x00.\r\n",
-    "nullafter": "\r\n\x00.\r\n",
+    "nullafter": "\r\n.\x00\r\n",
     "pipelining": "Test whether server supports pipelining (Postfix mitigation)",
 }
 


### PR DESCRIPTION
in the test case with the zero byte after the dot, the zero byte was before the dot